### PR TITLE
OptionTを利用(動作確認済) [質問]

### DIFF
--- a/app/controllers/api/Category.scala
+++ b/app/controllers/api/Category.scala
@@ -17,14 +17,16 @@ import play.api.data.format.{ Formats, Formatter }
 import play.api.data.format.Formats._
 import play.api.i18n.I18nSupport
 import ixias.model.IdStatus.Exists
+import cats.data._
+import cats.implicits._
 
 import lib.model._
 import lib.persistence.default.CategoryRepository
+import lib.persistence.default.CategoryRepository._
 import play.api.libs.json.JsValue
 import model._
 import model.json._
 import java.lang.Exception
-
 
 @Singleton
 class CategoryController @Inject()(
@@ -66,20 +68,36 @@ class CategoryController @Inject()(
     )
   }
   def get(id:Long) = Action async { implicit req =>
-    for {
-      optionCategory <- CategoryRepository.get(Category.Id(id))
-    } yield {
-      optionCategory match {
+    for{
+      categoryT <- OptionT.liftF( CategoryRepository.get(Category.Id(id))).getOrElse(None)
+
+    }yield{
+      categoryT match{
+        case Some(category) => {
+          val json = CategoryJsonResponseBody.write(category)
+           Ok(Json.toJson(json))
+        }
         case None => {
           val json = ErrorJson.write("Category=" + id + " は存在しません。")
           NotFound(Json.toJson(json))
-        };
-        case Some(categoryEmbed) => {
-          val json = CategoryJsonResponseBody.write(categoryEmbed)
-          Ok(Json.toJson(json))
         }
       }
     }
+    // 元の実装
+    // for {
+    //   optionCategory <- CategoryRepository.get(Category.Id(id))
+    // } yield {
+    //   optionCategory match {
+    //     case None => {
+    //       val json = ErrorJson.write("Category=" + id + " は存在しません。")
+    //       NotFound(Json.toJson(json))
+    //     };
+    //     case Some(categoryEmbed) => {
+    //       val json = CategoryJsonResponseBody.write(categoryEmbed)
+    //       Ok(Json.toJson(json))
+    //     }
+    //   }
+    // }
   }
   def update(id:Long) = Action(parse.json) async { implicit req =>
     req.body.validate[CategoryJsonRequestBody].fold(


### PR DESCRIPTION
# [Slackより](https://nextbeat-to-outside.slack.com/archives/C048HDU0T4Z/p1669951047674659)
api.category.get(id)をOptionTを利用して、リファクタリングしてみて、
動作確認出来ましたので、
答え合わせとして、園ナビ(ennavi-app)のsite.children.FacilityDetailController
を見てみたのですが、たくさん疑問点がありまして、
お手数ですが、教えていただければと思います

- 戸田の実装について
  - コンパイル、API動作は確認できましたが、OptionT の旨味(OptionTを使うことによりコードをスッキリまとめやすくなる)が死んている気がしています
    - 恐らくgetOrElse が原因と思いますが、ennnavi-appに習って、toRight を使おうとしましたが、これだと、Eitherが返ってきて、どうにも判断がつかなかったです
    - 率直に、どこに問題があるのか、ヒントか助けていただきたいです
- ennnavi-appについて、
  - OptionTを利用している箇所とそうではない箇所がありましたが、利用の判断基準は戻り値がFuture[Option[A]] の場合利用する　で、合っていますでしょうか？
- 他
  - EitherTを使う場面が全くイメージ出来なかったのですが、想像では、以下イメージでした。他の判断の材料になるものがりましたら、教えていただきたいです
    - OptionT().toRight()→EitherT？
    - ennnavi-appでは、toRight(Notfound) でエラー処理しているように見えました